### PR TITLE
class_time.php > lasttime > Prevent TypeError in PHP 8

### DIFF
--- a/include/class_time.php
+++ b/include/class_time.php
@@ -226,7 +226,7 @@ class time{
 			$datum = $this->timecount($_timeTable);
 		}
 		// letzten Monat überprüfen falls in diesem keine Einträge drin sind
-		if(count($_timeTable)<1){
+		if($_timeTable === NULL){
 			$monat = $monat-1;
 			$_file = "./Data/".$_ordnerpfad."/Timetable/" . $jahr . "." . $monat;
 			if(file_exists($_file)){


### PR DESCRIPTION
Prior to PHP 8.0.0, if the parameter was neither an array nor an object that implements the Countable interface, 1 would be returned, unless value was null, in which case 0 would be returned.

With PHP 8 count() will now throw TypeError on invalid countable types passed to the value parameter.