### PR TITLE
Docker optimizations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.dockerignore
+.git*
+changelog.txt
+docker-compose.yml
+node_modules
+tmp/
+Dockerfile
+Makefile
+README.md
+*.log
+# Ignore instead of removing after copying to the image
+android.php
+idtime.php
+stempelterminal.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,6 @@ RUN apt-get update && apt-get install -y \
     && chmod -R 750 /var/www/html/import \
     && chmod -R 750 /var/www/html/debug \
     && chmod -R 750 /var/www/html/include/Settings \
-    && rm -f /var/www/html/android.php \
-       /var/www/html/idtime.php \
-       /var/www/html/stempelterminal.php \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && apt-get install -y \
     && chown -R www-data:www-data /var/www/html \
     && chmod -R 755 /var/www/html \
     && chmod -R 750 /var/www/html/Data \
-    && chmod -R 750 /var/www/html/import \
-    && chmod -R 750 /var/www/html/debug \
-    && chmod -R 750 /var/www/html/include/Settings \
+       /var/www/html/import \
+       /var/www/html/debug \
+       /var/www/html/include/Settings \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,22 @@ FROM php:8.2-apache
 
 WORKDIR /var/www/html
 
-RUN apt-get update && apt-get install -y \
-    libzip-dev \
-    libxml2-dev \
-    && docker-php-ext-install zip xml
-
-RUN a2enmod rewrite
-
 COPY . /var/www/html/
 
-RUN chown -R www-data:www-data /var/www/html \
+RUN apt-get update && apt-get install -y \
+       libzip-dev \
+       libxml2-dev \
+    && docker-php-ext-install zip xml \
+    && a2enmod rewrite \
+    && chown -R www-data:www-data /var/www/html \
     && chmod -R 755 /var/www/html \
     && chmod -R 750 /var/www/html/Data \
     && chmod -R 750 /var/www/html/import \
     && chmod -R 750 /var/www/html/debug \
-    && chmod -R 750 /var/www/html/include/Settings
-
-RUN rm -f /var/www/html/android.php \
-    /var/www/html/idtime.php \
-    /var/www/html/stempelterminal.php \
+    && chmod -R 750 /var/www/html/include/Settings \
+    && rm -f /var/www/html/android.php \
+       /var/www/html/idtime.php \
+       /var/www/html/stempelterminal.php \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This are changes to reduce the Docker image size and layers. There are also some code style changes included.

```
❯ docker images
REPOSITORY          TAG       IMAGE ID       CREATED              SIZE
<none>              <none>    bfc0c348fc55   About a minute ago   577MB
<none>              <none>    edc44c6ffbc0   44 minutes ago       608MB
❯ docker history edc44c6ffbc0 --format '{{.ID}}' | wc -l
      37
❯ docker history bfc0c348fc55 --format '{{.ID}}' | wc -l
      34
```

`edc44c6ffbc0` is the result of `docker build .` of the actual `Dockerfile` while  `bfc0c348fc55` was build on this changes.
